### PR TITLE
enable toggle for net

### DIFF
--- a/fixes/90akonmdispatcher
+++ b/fixes/90akonmdispatcher
@@ -1,9 +1,14 @@
 #!/bin/bash
 #setup dnsmasq on IP address change
 if [ "$2" = "up" ];then
-	. /usr/bin/networkvariables.sh
-	if [ ! -z "$DHCPD_INTERFACE" ]; then
-		iptables -t nat -A POSTROUTING -o $DHCPD_INTERFACE -j MASQUERADE
+	if test -f /var/www/htdocs/ap.conf; then
+		. /var/www/htdocs/ap.conf
+		if [[ x"$NET_CONNECT == xtrue" ]]; then
+			. /usr/bin/networkvariables.sh
+			if [ ! -z "$DHCPD_INTERFACE" ]; then
+				iptables -t nat -A POSTROUTING -o $DHCPD_INTERFACE -j MASQUERADE
+			fi
+		fi
 	fi
 fi
 


### PR DESCRIPTION
create /var/www/htdocs/ap.conf, chown www-data 
put in that file:
NET_CONNECT=true

If the file is not present or the variable is missing then the internet connection will not be available to the clients.